### PR TITLE
Add support for CMD vs CMD-SHELL in healthcheck

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -134,7 +134,7 @@ func GetUnsupportedProperties(configDetails types.ConfigDetails) []string {
 
 func sortedKeys(set map[string]bool) []string {
 	var keys []string
-	for key, _ := range set {
+	for key := range set {
 		keys = append(keys, key)
 	}
 	sort.Strings(keys)
@@ -467,6 +467,8 @@ func convertField(
 	switch fieldTag {
 	case "":
 		return data, nil
+	case "healthcheck":
+		return loadHealthcheck(data)
 	case "list_or_dict_equals":
 		return loadMappingOrList(data, "="), nil
 	case "list_or_dict_colon":
@@ -569,6 +571,14 @@ func loadShellCommand(value interface{}) (interface{}, error) {
 		return shellwords.Parse(str)
 	}
 	return value, nil
+}
+
+func loadHealthcheck(value interface{}) (interface{}, error) {
+	if str, ok := value.(string); ok {
+		words, err := shellwords.Parse(str)
+		return append([]string{"CMD-SHELL"}, words...), err
+	}
+	return append([]string{"CMD"}, value.([]string)...), nil
 }
 
 func loadSize(value interface{}) (int64, error) {

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -603,6 +603,7 @@ func TestFullExample(t *testing.T) {
 		},
 		HealthCheck: &types.HealthCheckConfig{
 			Command: []string{
+				"CMD-SHELL",
 				"cat",
 				"/etc/passwd",
 			},

--- a/types/types.go
+++ b/types/types.go
@@ -124,7 +124,7 @@ type DeployConfig struct {
 }
 
 type HealthCheckConfig struct {
-	Command  []string `compose:"shell_command"`
+	Command  []string `compose:"healthcheck"`
 	Timeout  string
 	Interval string
 	Retries  *uint64


### PR DESCRIPTION
If the healthcheck is specified as a string, we use `CMD-SHELL` and if it's specified as a list, we use `CMD`. This maps with the `Dockerfile` behavior.

/cc @aanand @dnephin 

🐸

Signed-off-by: Vincent Demeester <vincent@sbr.pm>