### PR TITLE
Fix services networks list to be ignored when loading

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -515,13 +515,12 @@ func toYAMLName(name string) string {
 }
 
 func loadListOrStructMap(value interface{}, target reflect.Type) (interface{}, error) {
-	mapValue := reflect.MakeMap(target)
-
 	if list, ok := value.([]interface{}); ok {
+		mapValue := map[interface{}]interface{}{}
 		for _, name := range list {
-			mapValue.SetMapIndex(reflect.ValueOf(name), reflect.ValueOf(nil))
+			mapValue[name] = nil
 		}
-		return mapValue.Interface(), nil
+		return mapValue, nil
 	}
 
 	return value, nil

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -32,10 +32,14 @@ version: "3"
 services:
   foo:
     image: busybox
+    networks:
+      with_me:
   bar:
     image: busybox
     environment:
       - FOO=1
+    networks:
+      - with_ipam
 volumes:
   hello:
     driver: default
@@ -58,10 +62,12 @@ var sampleDict = types.Dict{
 	"services": types.Dict{
 		"foo": types.Dict{
 			"image": "busybox",
+			"networks": types.Dict{"with_me": nil},
 		},
 		"bar": types.Dict{
 			"image":       "busybox",
 			"environment": []interface{}{"FOO=1"},
+			"networks": []interface{}{"with_ipam"},
 		},
 	},
 	"volumes": types.Dict{
@@ -98,11 +104,17 @@ var sampleConfig = types.Config{
 			Name:        "foo",
 			Image:       "busybox",
 			Environment: map[string]string{},
+			Networks: map[string]*types.ServiceNetworkConfig{
+				"with_me": nil,
+			},
 		},
 		{
 			Name:        "bar",
 			Image:       "busybox",
 			Environment: map[string]string{"FOO": "1"},
+			Networks: map[string]*types.ServiceNetworkConfig{
+				"with_ipam": nil,
+			},
 		},
 	},
 	Networks: map[string]types.NetworkConfig{


### PR DESCRIPTION
Given the following service in a compose file

```yaml
foo:
  image: busybox
  networks:
    - network1
    - network2
```

Both these networks were not present in the `ServiceConfig` struct after loading.

It's fixed by using less `reflect` magic in `loadListOrStructMap`. The main problem with `reflect` and here `SetMapIndex` is :

>  SetMapIndex sets the value associated with key in the map v to val. It panics if v's Kind is not Map. **If val is the zero Value, SetMapIndex deletes the key from the map**. Otherwise if v holds a nil map, SetMapIndex will panic. As in Go, key's value must be assignable to the map's key type, and val's value must be assignable to the map's value type.

That's exactly what the method was doing, setting a zero Value, and thus keys were never added to the map. The use of `reflect` here is not required :angel:.

The related issue is docker/docker#28635. Once merged here, I'll update the vendoring in `docker/docker` :angel: 

/cc @aanand @dnephin 

:frog: 

Signed-off-by: Vincent Demeester <vincent@sbr.pm>