### PR TITLE
Update extends error message

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -35,7 +35,7 @@ var DeprecatedProperties = map[string]string{
 }
 
 var ForbiddenProperties = map[string]string{
-	"extends":       "Support for `extends` is not implemented yet. Use `docker-compose config` to generate a configuration with all `extends` options resolved, and deploy from that.",
+	"extends":       "`extends` is not supported.",
 	"volume_driver": "Instead of setting the volume driver on the service, define a volume using the top-level `volumes` option and specify the driver there.",
 	"volumes_from":  "To share a volume between services, define it using the top-level `volumes` option and reference it from each service that shares it using the service-level `volumes` option.",
 	"cpu_quota":     "Set resource limits using deploy.resources",


### PR DESCRIPTION
@shin-, @vdemeester 

https://github.com/docker/compose/issues/4315

The error message on `extends` was misleading. What do you think about this?

I'm not sure there is really anything else we can tell them about it.